### PR TITLE
Refactored validations and transformers

### DIFF
--- a/src/deconfig/__version__.py
+++ b/src/deconfig/__version__.py
@@ -4,6 +4,6 @@ Deconfig Version Information
 
 __title__ = "deconfig"
 __description__ = "Decorator driven Configuration Library"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "ybhaw"
 __license__ = "MIT"

--- a/src/deconfig/core.py
+++ b/src/deconfig/core.py
@@ -13,6 +13,17 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
+def is_callable(callback: Callable[..., T]) -> bool:
+    """
+    Check if function is callable.
+    """
+    if not callback:
+        raise TypeError("Callback is required.")
+    if not callable(callback):
+        raise TypeError("Callback must be a callable.")
+    return True
+
+
 class AdapterError(Exception):
     """
     Raised when adapter fails to get field value.

--- a/src/deconfig/validations.py
+++ b/src/deconfig/validations.py
@@ -1,0 +1,187 @@
+"""
+A simple validation library for Python.
+Useful to validate configurations, but can be used with any method.
+
+Example Usage:
+    @is_string()
+    @field(name="app_setting")
+    def get_app_settings() -> str:
+        return "app_settings"
+"""
+
+from enum import Enum
+from typing import Callable, TypeVar, Any, Type, Pattern, Optional
+from deconfig.__version__ import __version__, __author__, __license__
+
+__description__ = "A simple validation library for Python."
+
+from deconfig.core import is_callable
+
+T = TypeVar("T")
+Comparable = TypeVar("Comparable")
+
+
+def validate(callback: Callable[[Any], None]) -> Callable[..., T]:
+    """
+    Validate the output of what a method returns.
+    This should be used as a decorator.
+
+    Example:
+        def is_string(response: Any) -> None:
+            if not isinstance(response, str):
+                raise ValueError("Response is not a string.")
+
+        @validate(is_string)
+        def get_foo() -> str:
+            return "foo"
+    """
+    is_callable(callback)
+
+    def wrapper(func: Callable[..., T]) -> Callable[..., T]:
+        def validate_and_call(*args, **kwargs):
+            response = func(*args, **kwargs)
+            try:
+                callback(response)
+            except ValueError as e:
+                raise ValueError(
+                    f'Validation failed for "{func.__name__}" method.'
+                ) from e
+            return response
+
+        validate_and_call: func = validate_and_call
+        return validate_and_call
+
+    return wrapper
+
+
+def is_datatype(datatype: Type) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns is of a specific datatype.
+    :param datatype: Type of the datatype to validate.
+    :raises ValueError: If the response is not of the specified datatype.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if not isinstance(response, datatype):
+            raise ValueError(f'Response is not a "{datatype.__name__}".')
+
+    return validate(validation_callback)
+
+
+def is_not_empty(response: Any) -> None:
+    """
+    Validate the output of what a method returns is not empty.
+    :param response:
+    :raises ValueError: If the response is empty.
+    """
+    if not response:
+        raise ValueError("Response is empty.")
+
+
+def is_in_range(
+    min_value: Comparable,
+    max_value: Comparable,
+    left_inclusive: bool = True,
+    right_inclusive: bool = True,
+) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns is within a range.
+    :param min_value: Minimum value.
+    :param max_value: Maximum value.
+    :param left_inclusive: If the minimum value is inclusive.
+    :param right_inclusive: If the maximum value is inclusive.
+    :raises ValueError: If the response is not within the range.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if min_value is not None:
+            if left_inclusive and response < min_value:
+                raise ValueError(f"Response is less than {min_value}.")
+            if not left_inclusive and response <= min_value:
+                raise ValueError(f"Response is less than or equal to {min_value}.")
+        if max_value is not None:
+            if right_inclusive and response > max_value:
+                raise ValueError(f"Response is greater than {max_value}.")
+            if not right_inclusive and response >= max_value:
+                raise ValueError(f"Response is greater than or equal to {max_value}.")
+
+    return validate(validation_callback)
+
+
+def matches_pattern(pattern: Pattern) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns matches a pattern.
+    :param pattern: regex pattern to match.
+    :raises ValueError: If the response does not match the pattern.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if not pattern.match(response):
+            raise ValueError("Response does not match the pattern.")
+
+    return validate(validation_callback)
+
+
+def max_length(length: int) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns is less than a specific length.
+    :param length: Maximum length (inclusive).
+    :raises ValueError: If the response length is greater than the specified length.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if len(response) > length:
+            raise ValueError(f"Response length is greater than {length}.")
+
+    return validate(validation_callback)
+
+
+def min_length(length: int) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns is greater than a specific length.
+    :param length: Minimum length (inclusive).
+    :raises ValueError: If the response length is less than the specified length.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if len(response) < length:
+            raise ValueError(f"Response length is less than {length}.")
+
+    return validate(validation_callback)
+
+
+def is_in_enum(
+    enum: Type[Enum], use_value: Optional[bool] = False
+) -> Callable[..., None]:
+    """
+    Validate the output of what a method returns is in an Enum.
+    :param enum: Enum to validate against.
+    :param use_value: If the Enum value should be used instead of the Enum.
+    :raises ValueError: If the response is not in the Enum.
+    """
+
+    def validation_callback(response: Any) -> None:
+        if use_value:
+            if response not in [e.value for e in enum]:
+                raise ValueError("Response is not in the enum.")
+        else:
+            if not isinstance(response, enum):
+                raise ValueError("Response is not in the enum.")
+
+    return validate(validation_callback)
+
+
+__all__ = [
+    "validate",
+    "is_datatype",
+    "is_not_empty",
+    "is_in_range",
+    "matches_pattern",
+    "max_length",
+    "min_length",
+    "is_in_enum",
+    "__version__",
+    "__author__",
+    "__description__",
+    "__license__",
+]

--- a/tests/test_deconfig/test_core.py
+++ b/tests/test_deconfig/test_core.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from deconfig.core import FieldUtil, AdapterBase
+from deconfig.core import FieldUtil, AdapterBase, is_callable
 
 
 @pytest.fixture(name="stub_function")
@@ -15,6 +15,29 @@ def fixture_stub_function():
         """Stub Function"""
 
     return stub_function
+
+
+class TestIsCallable:
+    def test_Should_not_raise_error_When_is_callable_is_called_with_callable(self):
+        is_callable(lambda: None)
+
+    def test_Should_raise_type_error_When_is_callable_is_called_with_non_callable(self):
+        with pytest.raises(TypeError) as e:
+            is_callable(1)
+        assert str(e.value) == "Callback must be a callable."
+
+    # noinspection PyArgumentList,PyTypeChecker
+    def test_Should_raise_type_error_When_callable_is_missing(self):
+        with pytest.raises(TypeError) as e:
+            is_callable(None)
+        assert str(e.value) == "Callback is required."
+
+        with pytest.raises(TypeError) as e:
+            is_callable()  # pylint: disable=no-value-for-parameter
+        assert (
+            str(e.value)
+            == "is_callable() missing 1 required positional argument: 'callback'"
+        )
 
 
 class TestAdapterConfig:

--- a/tests/test_deconfig/test_deconfig.py
+++ b/tests/test_deconfig/test_deconfig.py
@@ -6,20 +6,19 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from deconfig.core import AdapterBase, AdapterError
+import deconfig
 
 # noinspection PyProtectedMember
 from deconfig import (
-    decorated_config_decorator,
+    _decorated_config_decorator,
     config,
     field,
     optional,
-    validate,
     add_adapter,
     set_default_adapters,
     EnvAdapter,
 )
-import deconfig
+from deconfig.core import AdapterBase, AdapterError, FieldUtil
 
 
 @pytest.mark.parametrize(
@@ -27,22 +26,18 @@ import deconfig
     [
         "field",
         "optional",
-        "validate",
         "add_adapter",
         "set_default_adapters",
         "config",
-        "transform",
         "EnvAdapter",
         "IniAdapter",
     ],
     ids=[
         "field",
         "optional",
-        "validate",
         "add_adapter",
         "set_default_adapters",
         "config",
-        "transform",
         "EnvAdapter",
         "IniAdapter",
     ],
@@ -59,10 +54,17 @@ def fixture_stub_callable():
     return stub_callable
 
 
+# noinspection PyArgumentList,PyTypeChecker
 class TestField:
-    def test_Should_raise_type_error_When_name_is_none(self):
+    # pylint: disable=no-value-for-parameter
+    def test_Should_raise_type_error_When_name_is_none_or_missing(self):
+        with pytest.raises(TypeError) as e:
+            field()(lambda: None)
+        assert str(e.value) == "field() missing 1 required positional argument: 'name'"
+
         with pytest.raises(TypeError) as e:
             field(None)(lambda: None)
+
         assert str(e.value) == "Name is required."
 
     def test_Should_raise_type_error_When_argument_is_not_string(self):
@@ -73,17 +75,22 @@ class TestField:
         with pytest.raises(TypeError):
             field(StubNotString())(lambda: None)
 
-    def test_Should_set_attribute_name_When_field_is_called(self, stub_callable):
-        test_field_decorated = field("test")(stub_callable)
+    def test_Should_set_attribute_name_When_field_is_called(self):
+        field_name = "stub_field_name"
 
-        assert test_field_decorated == stub_callable
-        assert hasattr(stub_callable, "name")
-        assert stub_callable.name == "test"
+        @field(field_name)
+        def stub_field():
+            """Pass"""
+
+        assert FieldUtil.has_name(stub_field) is True
+        assert FieldUtil.get_name(stub_field) == field_name
 
     def test_Should_set_attribute_adapter_configs_When_field_is_called(self):
-        mock_field = MagicMock()
-        response = deconfig.field("test")(mock_field)
-        assert hasattr(response, "adapter_configs")
+        def stub_method():
+            """Stub method"""
+
+        decorated_method = field("test")(stub_method)
+        assert FieldUtil.get_adapter_configs(decorated_method) == {}
 
     def test_Should_return_same_function_When_field_is_called(self):
         mock = MagicMock()
@@ -91,31 +98,47 @@ class TestField:
         assert response_callback == mock
 
 
+# noinspection PyTypeChecker
 class TestOptional:
-    def test_Should_set_attribute_optional_When_optional_is_called(self, stub_callable):
-        response = optional()(stub_callable)
-        assert hasattr(response, "optional")
-        assert response.optional is True
-        assert response == stub_callable
-
     def test_Should_return_same_function_When_optional_is_called(self):
         mock = MagicMock()
         response_callback = optional()(mock)
         assert response_callback == mock
 
+    def test_Should_return_false_When_optional_is_not_set(self):
+        @field(name="stub_function")
+        def stub_function():
+            """Stub function"""
+
+        assert FieldUtil.is_optional(stub_function) is False
+
+    def test_Should_set_true_When_optional_is_called_without_arguments(self):
+        @optional()
+        @field(name="stub_field")
+        def stub_field():
+            """Stub field"""
+
+        assert FieldUtil.is_optional(stub_field) is True
+
     def test_Should_set_attribute_optional_to_true_When_optional_is_called_with_true(
         self,
     ):
-        test_optional = optional(True)(lambda: None)
-        assert hasattr(test_optional, "optional")
-        assert test_optional.optional is True
+        @optional(True)
+        @field(name="stub_field")
+        def stub_field():
+            """Stub field"""
 
-    def test_Should_set_attribute_optional_to_false_When_optional_is_called_with_false(
+        assert FieldUtil.is_optional(stub_field) is True
+
+    def test_Should_be_false_When_optional_is_called_with_false(
         self,
     ):
-        test_optional = optional(False)(lambda: None)
-        assert hasattr(test_optional, "optional")
-        assert test_optional.optional is False
+        @optional(False)
+        @field(name="stub_field")
+        def stub_field():
+            """Stub field"""
+
+        assert FieldUtil.is_optional(stub_field) is False
 
     def test_Should_not_raise_type_error_When_argument_cannot_be_cast_to_bool(self):
         class StubNotBool:
@@ -123,180 +146,187 @@ class TestOptional:
                 raise TypeError("Not a bool")
 
         with pytest.raises(TypeError):
-            optional(StubNotBool())(lambda: None)
+            optional(StubNotBool())(field(name="stub_field")(lambda: None))
 
 
-class TestValidationCallback:
+@pytest.fixture(name="stub_adapter")
+def fixture_stub_adapter():
+    class StubAdapter(AdapterBase):
+        def get_field(self, field_name, method, *_, **__):
+            return "stub_adapter_response"
 
-    def test_Should_set_attribute_validation_callback_When_validate_is_called(
-        self, stub_callable
-    ):
-        test_validation = validate(stub_callable)(lambda: None)
-        assert hasattr(test_validation, "validation_callbacks")
-        assert test_validation.validation_callbacks == [stub_callable]
-
-    def test_Should_return_same_function_When_validate_is_called(self):
-        mock = MagicMock()
-        response_callback = validate(mock)(mock)
-        assert response_callback == mock
-
-    def test_Should_raise_type_error_When_argument_is_none(self):
-        with pytest.raises(TypeError):
-            validate(None)(lambda: None)
-
-    def test_Should_raise_type_error_When_argument_is_not_callable(self):
-        with pytest.raises(TypeError):
-            validate(1)(lambda: None)
+    return StubAdapter()
 
 
+# noinspection PyTypeChecker
 class TestAddAdapter:
-    def test_Should_set_attribute_adapters_When_add_adapter_is_called(self):
-        mock_adapter = MagicMock(AdapterBase)
-        get_field_with_added_adapter = add_adapter(mock_adapter())(lambda: None)
-        assert hasattr(get_field_with_added_adapter, "adapters")
-        assert get_field_with_added_adapter.adapters == [mock_adapter.return_value]
 
-    def test_Should_return_same_function_When_add_adapter_is_called(self):
-        mock = MagicMock(AdapterBase)
-        response_callback = add_adapter(mock)(mock)
-        assert response_callback == mock
+    def test_Should_set_attribute_adapters_When_add_adapter_is_called(
+        self, stub_adapter
+    ):
+        @add_adapter(stub_adapter)
+        @field(name="test")
+        def stub_field():
+            """Stub field"""
+
+        assert FieldUtil.get_adapters(stub_field) == [stub_adapter]
+
+    def test_Should_return_same_function_When_add_adapter_is_called(self, stub_adapter):
+        @field(name="test")
+        def stub_field():
+            """Stub Field"""
+
+        assert stub_field == add_adapter(stub_adapter)(stub_field)
 
     def test_Should_add_adapter_to_existing_adapters_When_add_adapter_is_called(self):
-        adapter_1 = MagicMock(AdapterBase)
-        field_mock = MagicMock()
-        field_mock.adapters = [adapter_1.return_value]
+        class StubAdapter1(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                return "stub_adapter_response_1"
 
-        adapter_2 = MagicMock(AdapterBase)
-        field_mock_with_decorator = add_adapter(adapter_2())(field_mock)
-        assert hasattr(field_mock_with_decorator, "adapters")
-        assert field_mock_with_decorator.adapters == [
-            adapter_2.return_value,
-            adapter_1.return_value,
-        ]
+        class StubAdapter2(AdapterBase):
+            called_once = False
+            error_raised = False
 
-        adapter_3 = MagicMock(AdapterBase)
-        field_mock_with_third_adapter = add_adapter(adapter_3())(
-            field_mock_with_decorator
-        )
-        assert hasattr(field_mock_with_third_adapter, "adapters")
-        assert field_mock_with_third_adapter.adapters == [
-            adapter_3.return_value,
-            adapter_2.return_value,
-            adapter_1.return_value,
-        ]
+            def get_field(self, field_name, method, *_, **__):
+                if not self.called_once:
+                    self.called_once = True
+                    return "stub_adapter_response_2"
+                raise AdapterError("Intentional error")
 
-    def test_Should_add_adapter_as_new_list_When_add_adapter_is_called(
-        self, stub_callable
-    ):
-        mock_adapter = MagicMock(AdapterBase)
-        assert not hasattr(stub_callable, "adapters")
-        field_decorated = add_adapter(mock_adapter())(stub_callable)
-        assert hasattr(field_decorated, "adapters")
-        assert field_decorated.adapters == [mock_adapter.return_value]
-
-    def test_Should_raise_value_error_When_argument_is_none(self):
-        with pytest.raises(TypeError):
-            add_adapter(None)(lambda: None)
-
-    def test_Should_raise_value_error_When_argument_is_not_adapter_base(self):
-        with pytest.raises(TypeError):
-            add_adapter(1)(lambda: None)
-
-
-class TestSetDefaultAdapters:
-    def test_Should_set_default_adapters_to_env_adapter_When_set_default_adapters_is_not_called(
-        self,
-    ):
-        _adapters = deconfig._adapters  # pylint: disable=protected-access
-        assert len(_adapters) == 1
-        assert isinstance(_adapters[0], EnvAdapter)
-        mocked_adapter = MagicMock(AdapterBase)
-        config_response = MagicMock("config_response")
-        mocked_adapter.get_field.return_value = config_response
-        _adapters.insert(0, mocked_adapter)
+        stub_adapter_2 = StubAdapter2()
 
         @config()
         class StubConfig:
+            @add_adapter(stub_adapter_2)
+            @add_adapter(StubAdapter1())
             @field(name="test")
             def stub_field(self):
                 """Stub field"""
 
-        test_config = StubConfig()
-        assert test_config.stub_field() == config_response
+        stub_config = StubConfig()
+        assert stub_config.stub_field() == "stub_adapter_response_2"
+        stub_config.reset_deconfig_cache()
+        assert stub_config.stub_field() == "stub_adapter_response_1"
+        with pytest.raises(AdapterError):
+            stub_adapter_2.get_field("test", stub_config.stub_field)
+
+    def test_Should_add_adapter_as_new_list_When_add_adapter_is_called(
+        self, stub_callable, stub_adapter
+    ):
+        assert not FieldUtil.has_adapters(stub_callable)
+        field_decorated = add_adapter(stub_adapter)(stub_callable)
+        assert FieldUtil.has_adapters(field_decorated)
+        assert FieldUtil.get_adapters(field_decorated) == [stub_adapter]
+
+    def test_Should_raise_value_error_When_argument_is_none(self):
+        with pytest.raises(TypeError) as e:
+            add_adapter(None)(field(name="test")(lambda: None))
+
+        assert str(e.value) == "Adapter is required."
+
+    def test_Should_raise_value_error_When_argument_is_not_adapter_base(self):
+        with pytest.raises(TypeError) as e:
+            add_adapter(1)(field(name="test")(lambda: None))
+
+        assert (
+            str(e.value) == "Adapter must extend AdapterBase or have get_field method."
+        )
+
+
+# noinspection PyTypeChecker
+class TestSetDefaultAdapters:
+    def test_Should_set_default_adapters_to_env_adapter_When_set_default_adapters_is_not_called(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("STUB_FIELD", "stub_response")
+
+        @config()
+        class StubConfig:
+            @field(name="stub_field")
+            def stub_field(self):
+                """Stub field"""
+
+        stub_config = StubConfig()
+        assert stub_config.stub_field() == "stub_response"
 
     def test_Should_raise_type_error_When_set_default_adapters_is_called_with_no_adapters(
         self,
     ):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as e:
             set_default_adapters()
+
+        assert str(e.value) == "At least one adapter is required."
 
     def test_Should_raise_type_error_When_set_default_adapters_is_called_with_non_adapter_base(
         self,
     ):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as e:
             set_default_adapters(1)
-        with pytest.raises(TypeError):
+
+        assert (
+            str(e.value) == "Adapter must extend AdapterBase or have get_field method."
+        )
+
+        with pytest.raises(TypeError) as e:
             set_default_adapters(EnvAdapter(), 1)
 
-    def test_Should_set_default_adapters_to_given_adapters_When_set_default_adapters_is_called_with_adapters(
-        self,
-    ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
+        assert (
+            str(e.value) == "Adapter must extend AdapterBase or have get_field method."
+        )
 
-        set_default_adapters(adapter)
+    def test_Should_set_default_adapters_to_given_adapters_When_set_default_adapters_is_called_with_adapters(
+        self, stub_adapter, monkeypatch
+    ):
+        monkeypatch.setenv("STUB_ENV_FIELD", "stub_env_response")
+        set_default_adapters(stub_adapter)
 
         @config()
         class StubConfig:
-            @field(name="field")
-            def test_field(self):
+            @field(name="default_adapter")
+            def default_stub_field(self):
+                """Stub field"""
+
+            @add_adapter(EnvAdapter())
+            @field(name="stub_env_field")
+            def stub_env_field(self):
                 """Stub field"""
 
         stub_config = StubConfig()
-        assert stub_config.test_field() == adapter_response
+        assert stub_config.stub_env_field() == "stub_env_response"
+        assert stub_config.default_stub_field() == "stub_adapter_response"
 
 
 class TestConfig:
-    def test_Should_use_env_adapter_When_no_adapters_are_set(self):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
-        deconfig._adapters = [adapter]  # pylint: disable=protected-access
+
+    def test_Should_use_env_adapter_When_no_adapters_are_set(self, monkeypatch):
+        monkeypatch.setenv("STUB_ENV_FIELD", "stub_env_response")
+        set_default_adapters(EnvAdapter())
 
         @config()
         class StubConfig:
-            @field(name="test")
+            @field(name="stub_env_field")
             def field_stub(self):
                 """Stub Field"""
 
         stub_config = StubConfig()
-        assert stub_config.field_stub() == adapter_response
+        assert stub_config.field_stub() == "stub_env_response"
 
     def test_Should_update_and_use_class_adapters_When_adapters_set_using_decorator_args(
-        self,
+        self, stub_adapter
     ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
-
-        @config([adapter])
+        @config([stub_adapter])
         class StubConfig:
             @field(name="test")
             def field_stub(self):
                 """Stub Field"""
 
         stub_config = StubConfig()
-        assert stub_config.field_stub() == adapter_response
+        assert stub_config.field_stub() == "stub_adapter_response"
 
-    def test_Should_update_and_use_class_adapters_When_adapters_set_using_set_default_adapters(
-        self,
+    def test_Should_update_and_use_default_adapters_When_adapters_set_using_set_default_adapters(
+        self, stub_adapter
     ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
-
-        set_default_adapters(adapter)
+        set_default_adapters(stub_adapter)
 
         @config()
         class StubConfig:
@@ -305,36 +335,32 @@ class TestConfig:
                 """Stub Field"""
 
         stub_config = StubConfig()
-        assert stub_config.field_stub() == adapter_response
+        assert stub_config.field_stub() == "stub_adapter_response"
 
     def test_Should_prioritize_config_args_When_config_has_adapters_and_default_is_also_set(
-        self,
+        self, stub_adapter
     ):
-        default_adapter = MagicMock(AdapterBase)
+        class StubAdapter2(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                return "stub_adapter_response_2"
 
-        arg_adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        arg_adapter.get_field.return_value = adapter_response
+        set_default_adapters(stub_adapter)
 
-        set_default_adapters(default_adapter)
-
-        @config([arg_adapter])
+        @config([StubAdapter2()])
         class StubConfig:
+
+            @add_adapter(StubAdapter2())
             @field(name="test")
             def field_stub(self):
                 """Stub Field"""
 
         stub_config = StubConfig()
-        assert stub_config.field_stub() == adapter_response
+        assert stub_config.field_stub() == "stub_adapter_response_2"
 
     def test_Should_only_configure_methods_with_field_decorator_When_config_is_called(
-        self,
+        self, stub_adapter
     ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
-
-        @config(adapters=[adapter])
+        @config(adapters=[stub_adapter])
         class StubConfig:
             # noinspection PyMethodMayBeStatic
             def stub_method_without_field_decorator(self):
@@ -346,22 +372,25 @@ class TestConfig:
                 """Field with adapter"""
 
         stub_config = StubConfig()
-        assert stub_config.stub_method_with_field_decorator() == adapter_response
+        assert stub_config.stub_method_with_field_decorator() == "stub_adapter_response"
         assert stub_config.stub_method_without_field_decorator() == 1
-        assert adapter.get_field.call_count == 1
 
     def test_Should_prioritize_methods_adapters_When_method_has_adapters(self):
-        method_adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        method_adapter.get_field.return_value = adapter_response
+        class StubAdapter1(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                if field_name == "no_has_no_value":
+                    raise AdapterError("Intentional error")
+                return "stub_adapter_response_1"
 
-        class_adapter = MagicMock(AdapterBase)
-        default_adapter_response = MagicMock("default_adapter_response")
-        class_adapter.get_field.return_value = default_adapter_response
+        class StubAdapter2(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                if field_name == "no_has_no_value":
+                    raise AdapterError("Intentional error")
+                return "stub_adapter_response_2"
 
-        @config(adapters=[class_adapter])
+        @config(adapters=[StubAdapter1()])
         class StubConfig:
-            @add_adapter(method_adapter)
+            @add_adapter(StubAdapter2())
             @field(name="test")
             def method_with_field_adapter(self):
                 """Field with adapter"""
@@ -370,71 +399,70 @@ class TestConfig:
             def method_without_field_decorator(self):
                 """Field without adapter"""
 
-        stub_config = StubConfig()
-        assert stub_config.method_with_field_adapter() == adapter_response
-        assert stub_config.method_without_field_decorator() == default_adapter_response
-        assert method_adapter.get_field.call_count == 1
-        assert class_adapter.get_field.call_count == 1
-
-    def test_Should_use_class_adapters_When_field_missing_in_field_adapters(self):
-        method_adapter = MagicMock(AdapterBase)
-        method_adapter.get_field.side_effect = AdapterError("Intentional error")
-
-        class_adapter = MagicMock(AdapterBase)
-        default_adapter_response = MagicMock("default_adapter_response")
-        class_adapter.get_field.return_value = default_adapter_response
-
-        @config(adapters=[class_adapter])
-        class StubConfig:
-            @add_adapter(method_adapter)
-            @field(name="test")
-            def method_with_field_adapter(self):
+            @add_adapter(StubAdapter2())
+            @field(name="no_has_no_value")
+            def method_with_no_value(self):
                 """Field with adapter"""
 
-            @field(name="test_2")
-            def method_without_field_decorator(self):
-                """Field without adapter"""
-
         stub_config = StubConfig()
-        assert stub_config.method_with_field_adapter() == default_adapter_response
-        assert method_adapter.get_field.call_count == 1
-        assert class_adapter.get_field.call_count == 1
+        assert stub_config.method_with_field_adapter() == "stub_adapter_response_2"
+        assert stub_config.method_without_field_decorator() == "stub_adapter_response_1"
+        with pytest.raises(ValueError):
+            stub_config.method_with_no_value()
 
-    def test_Should_update_field_methods_with_decorated_config_decorator_When_class_is_decorated_with_config(
-        self,
+    def test_Should_use_class_adapters_When_field_missing_in_field_adapters(
+        self, stub_adapter
     ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
+        class StubAdapter2(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                if field_name == "field_present_in_adapter_2":
+                    return "stub_adapter_response_2"
+                raise AdapterError("Intentional error")
 
-        @config([adapter])
+        @config(adapters=[stub_adapter])
+        class StubConfig:
+            @add_adapter(StubAdapter2())
+            @field(name="field_present_in_adapter_2")
+            def method_with_field_adapter(self):
+                """Field with adapter"""
+
+            @add_adapter(StubAdapter2())
+            @field(name="field_missing_in_adapter_2")
+            def method_without_field_adapter(self):
+                """Field with adapter"""
+
+            @field(name="test_2")
+            def method_without_field_decorator(self):
+                """Field without adapter"""
+
+        stub_config = StubConfig()
+        assert stub_config.method_with_field_adapter() == "stub_adapter_response_2"
+        assert stub_config.method_without_field_adapter() == "stub_adapter_response"
+        assert stub_config.method_without_field_decorator() == "stub_adapter_response"
+
+    def test_Should_have_original_function_When_class_is_decorated_with_config(
+        self, stub_adapter
+    ):
+        @config([stub_adapter])
         class StubConfig:
             @field(name="test")
             def field_stub(self):
                 """Stub Field"""
 
         stub_config = StubConfig()
-        assert stub_config.field_stub() == adapter_response
-        assert stub_config.field_stub.__name__ == "decorated_config_wrapper"
+        assert FieldUtil.has_original_function(stub_config.field_stub)
 
     def test_Should_add_reset_deconfig_cache_method_When_class_is_decorated_with_config(
         self,
     ):
-        adapter = MagicMock(AdapterBase)
-        adapter_response = MagicMock("adapter_response")
-        adapter.get_field.return_value = adapter_response
-
-        @config([adapter])
+        @config()
         class StubConfig:
             @field(name="test")
             def field_stub(self):
                 """Stub Field"""
 
         stub_config = StubConfig()
-        stub_config.field_stub()
         assert hasattr(stub_config, "reset_deconfig_cache")
-        assert callable(stub_config.reset_deconfig_cache)
-        stub_config.reset_deconfig_cache()
 
     def test_Should_not_create_reset_deconfig_cache_When_class_already_has_reset_deconfig_cache_method(
         self,
@@ -451,135 +479,69 @@ class TestConfig:
             def field_stub(self):
                 """Stub Field"""
 
-            def reset_deconfig_cache(self):
+            @staticmethod
+            def reset_deconfig_cache():
                 """Method already present"""
                 return config_cache_stub
 
         stub_config = StubConfig()
-        assert hasattr(stub_config, "reset_deconfig_cache")
         assert stub_config.reset_deconfig_cache() == config_cache_stub
 
 
 class TestDecoratedConfigDecorator:
-    def test_Should_raise_value_error_When_field_name_is_not_present(
-        self, stub_callable
-    ):
-        with pytest.raises(ValueError) as e:
-            decorated_config_decorator(stub_callable)
-        assert (
-            str(e.value)
-            == "Have you forgotten to decorate field with @field(name='name')?"
-        )
-
     def test_Should_raise_value_error_When_adapters_are_not_present(
         self, stub_callable
     ):
         stub_callable.name = "test"
-        with pytest.raises(ValueError) as e:
-            decorated_config_decorator(stub_callable)
-        assert str(e.value) == "Class not decorated with @config"
+
+        class StubConfig:
+            @field(name="test")
+            def stub_field(self):
+                """Stub field"""
+                return "config_not_called"
+
+        stub_config = StubConfig()
+        assert stub_config.stub_field() == "config_not_called"
 
     def test_Should_mandate_field_be_present_in_config_false_When_optional_is_not_set_or_is_false(
         self,
     ):
-        adapter = MagicMock()
-        adapter.get_field.side_effect = AdapterError("Value not found")
+        class StubAdapter2(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                raise AdapterError("Intentional error")
 
-        def stub_callable_without_optional():
-            """Stub callable without optional"""
+        @config(adapters=[StubAdapter2()])
+        class StubConfig:
+            @field(name="test")
+            def stub_field(self):
+                """Stub field"""
 
-        stub_callable_without_optional.name = "test"
-        stub_callable_without_optional.adapters = [adapter]
-        response_callback = decorated_config_decorator(stub_callable_without_optional)
+        stub_config = StubConfig()
         with pytest.raises(ValueError) as e:
-            response_callback()
+            stub_config.stub_field()
         assert str(e.value) == "Field test not found in any config."
 
-        def stub_callable_with_optional_false():
-            """Stub callable with optional false"""
+    def test_Should_set_optional_to_true_When_optional_is_set_to_true(self):
+        class StubAdapter2(AdapterBase):
+            def get_field(self, field_name, method, *_, **__):
+                raise AdapterError("Intentional error")
 
-        stub_callable_with_optional_false.name = "test_2"
-        stub_callable_with_optional_false.adapters = [adapter]
-        stub_callable_with_optional_false.optional = False
-        response_callback = decorated_config_decorator(
-            stub_callable_with_optional_false
-        )
-        with pytest.raises(ValueError) as e:
-            response_callback()
-        assert str(e.value) == "Field test_2 not found in any config."
+        @config(adapters=[StubAdapter2()])
+        class StubConfig:
+            @optional()
+            @field(name="test")
+            def stub_field(self):
+                """Stub field"""
 
-    def test_Should_set_optional_to_true_When_optional_is_set_to_true(
-        self, stub_callable
-    ):
-        adapter = MagicMock()
-        adapter.get_field.side_effect = AdapterError("Value not found")
-
-        stub_callable.name = "test"
-        stub_callable.adapters = [adapter]
-        stub_callable.optional = True
-        response = decorated_config_decorator(stub_callable)
-        assert response() is None
-
-    def test_Should_call_validation_callback_When_set(self, stub_callable):
-        adapter = MagicMock()
-        adapter.get_field.return_value = 1
-
-        validation_callback = MagicMock()
-        stub_callable.name = "test"
-        stub_callable.adapters = [adapter]
-        stub_callable.validation_callbacks = [validation_callback]
-        response = decorated_config_decorator(stub_callable)
-        response()
-        validation_callback.assert_called_once_with(1)
-
-    def test_Should_raise_value_error_When_validation_callback_raises_error(
-        self, stub_callable
-    ):
-        adapter = MagicMock()
-        validation_callback = MagicMock()
-        validation_callback.side_effect = ValueError("Validation error")
-        stub_callable.name = "test"
-        stub_callable.adapters = [adapter]
-        stub_callable.validation_callbacks = [validation_callback]
-        response = decorated_config_decorator(stub_callable)
-        with pytest.raises(ValueError) as e:
-            response()
-        validation_callback.assert_called_once_with(adapter.get_field.return_value)
-        assert str(e.value) == "Validation error"
-
-    def test_Should_call_transform_callback_When_set(self, stub_callable):
-        adapter = MagicMock()
-        adapter.get_field.return_value = 1
-
-        transform_callback = MagicMock()
-        transform_callback.return_value = 2
-        stub_callable.name = "test"
-        stub_callable.adapters = [adapter]
-        stub_callable.transform_callbacks = [transform_callback]
-        response = decorated_config_decorator(stub_callable)
-        assert response() == 2
-        transform_callback.assert_called_once_with(1)
-
-    def test_Should_cache_transformed_response_When_invoked_and_has_transformer(
-        self, stub_callable
-    ):
-        adapter = MagicMock()
-        adapter.get_field.side_effect = [1]
-        stub_callable.name = "test"
-        stub_callable.adapters = [adapter]
-        transform_callback = MagicMock()
-        stub_callable.transform_callbacks = [transform_callback]
-        response = decorated_config_decorator(stub_callable)
-        assert response() == transform_callback.return_value
-        assert response() == transform_callback.return_value
-        assert transform_callback.call_count == 1
+        stub_config = StubConfig()
+        assert stub_config.stub_field() is None
 
     def test_Should_cache_response_When_invoked(self, stub_callable):
         adapter = MagicMock()
         adapter.get_field.side_effect = [1]
         stub_callable.name = "test"
         stub_callable.adapters = [adapter]
-        response = decorated_config_decorator(stub_callable)
+        response = _decorated_config_decorator(stub_callable)
         assert response() == 1
         assert response() == 1
         assert adapter.get_field.call_count == 1
@@ -618,7 +580,7 @@ class TestDecoratedConfigDecorator:
 
         stub_callable.name = "test"
         stub_callable.adapters = [adapter_1, adapter_2, adapter_3]
-        response = decorated_config_decorator(stub_callable)
+        response = _decorated_config_decorator(stub_callable)
         response()
         assert adapter_1.get_field.call_count == 1
         assert adapter_2.get_field.call_count == 1

--- a/tests/test_deconfig/test_validations.py
+++ b/tests/test_deconfig/test_validations.py
@@ -1,0 +1,289 @@
+"""
+Test cases for deconfig.validations module.
+"""
+
+import re
+from enum import Enum
+from unittest.mock import MagicMock
+
+import pytest
+
+from deconfig.validations import (
+    validate,
+    is_datatype,
+    is_not_empty,
+    is_in_range,
+    matches_pattern,
+    max_length,
+    min_length,
+    is_in_enum,
+)
+
+
+class TestValidate:
+    def test_Should_validate_against_callback_When_decorated_with_validate(self):
+        callable_stub = MagicMock()
+        callable_stub.side_effect = [MagicMock(), ValueError]
+
+        @validate(callable_stub)
+        def stub_function():
+            return 1
+
+        response = stub_function()
+        assert response == 1
+        assert callable_stub.call_count == 1
+
+        with pytest.raises(ValueError) as e:
+            stub_function()
+
+        assert str(e.value) == 'Validation failed for "stub_function" method.'
+        assert callable_stub.call_count == 2
+
+    # noinspection PyTypeChecker,PyArgumentList
+    def test_Should_raise_type_error_When_callback_is_missing(self):
+        with pytest.raises(TypeError) as e:
+            validate(None)(lambda: None)
+        assert str(e.value) == "Callback is required."
+
+        with pytest.raises(TypeError) as e:
+            validate()(lambda: None)  # pylint: disable=no-value-for-parameter
+        assert (
+            str(e.value)
+            == "validate() missing 1 required positional argument: 'callback'"
+        )
+
+    # noinspection PyTypeChecker
+    def test_Should_raise_type_error_When_callback_is_not_callable(self):
+        with pytest.raises(TypeError) as e:
+            validate(1)(lambda: None)
+        assert str(e.value) == "Callback must be a callable."
+
+
+class TestIsDatatype:
+    @pytest.mark.parametrize(
+        "datatype, response, is_valid",
+        [
+            (str, "foo", True),
+            (str, 1, False),
+            (int, 1, True),
+            (int, "foo", False),
+            (bool, True, True),
+            (bool, 1, False),
+            (float, 1.0, True),
+            (float, 1, False),
+        ],
+    )
+    def test_Should_validate_datatype_When_decorated_with_is_datatype(
+        self, datatype, response, is_valid
+    ):
+        @is_datatype(datatype)
+        def stub_function():
+            return response
+
+        if is_valid:
+            assert stub_function() == response
+        else:
+            with pytest.raises(ValueError) as e:
+                stub_function()
+            assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+class TestIsNotEmpty:
+    @pytest.mark.parametrize(
+        "response, is_valid",
+        [
+            (1, True),
+            ("foo", True),
+            ("", False),
+            (None, False),
+            ([], False),
+            ({}, False),
+            ((), False),
+        ],
+    )
+    def test_Should_validate_not_empty_When_decorated_with_is_not_empty(
+        self, response, is_valid
+    ):
+        @validate(is_not_empty)
+        def stub_function():
+            return response
+
+        if is_valid:
+            assert stub_function() == response
+        else:
+            with pytest.raises(ValueError) as e:
+                stub_function()
+            assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+# pylint: disable=too-many-arguments
+@pytest.mark.parametrize(
+    "response, start_value, end_value, left_inclusive, right_inclusive, is_valid",
+    [
+        (1, 0, 2, True, True, True),
+        (1, 0, 2, False, True, True),
+        (1, 0, 2, True, False, True),
+        (1, 0, 2, False, False, True),
+        (0, 0, 2, True, True, True),
+        (0, 0, 2, False, True, False),
+        (2, 0, 2, True, True, True),
+        (2, 0, 2, True, False, False),
+        (2, 0, 2, False, True, True),
+        (2, 0, 2, False, False, False),
+        (0, 1, 2, True, True, False),
+        (0, 1, 2, False, True, False),
+        (0, 1, 2, True, False, False),
+        (0, 1, 2, False, False, False),
+        (4, 1, 2, True, True, False),
+        (4, 1, 2, False, True, False),
+        (4, 1, 2, True, False, False),
+        (4, 1, 2, False, False, False),
+        ("41", "1", "5", False, False, True),
+    ],
+)
+def test_Should_validate_in_range_When_decorated_with_is_in_range(
+    response, start_value, end_value, left_inclusive, right_inclusive, is_valid
+):
+    @is_in_range(start_value, end_value, left_inclusive, right_inclusive)
+    def stub_function():
+        return response
+
+    if is_valid:
+        assert stub_function() == response
+    else:
+        with pytest.raises(ValueError) as e:
+            stub_function()
+        assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+@pytest.mark.parametrize(
+    "response, pattern, is_valid",
+    [
+        ("foo", re.compile("foo"), True),
+        ("foo", re.compile(r"bar"), False),
+        ("foo", re.compile(r"fo*"), True),
+        ("foo", re.compile(r"b.*"), False),
+        ("foo", re.compile(r"b.*"), False),
+        ("foo", re.compile(r"f.*"), True),
+        ("foo", re.compile(r".*"), True),
+        ("foo", re.compile(r".+"), True),
+        ("", re.compile(r".*"), True),
+    ],
+)
+def test_Should_validate_matches_pattern_When_decorated_with_matches_pattern(
+    response, pattern, is_valid
+):
+    @matches_pattern(pattern)
+    def stub_function():
+        return response
+
+    if is_valid:
+        assert stub_function() == response
+    else:
+        with pytest.raises(ValueError) as e:
+            stub_function()
+        assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+@pytest.mark.parametrize(
+    "response, max_length_value, is_valid",
+    [
+        ("foo", 3, True),
+        ("foo", 2, False),
+        ("foo", 4, True),
+        ("foo", 0, False),
+        ("foo", -1, False),
+        ("", 0, True),
+        ("", 1, True),
+        ("", -1, False),
+    ],
+)
+def test_Should_validate_max_length_When_decorated_with_max_length(
+    response, max_length_value, is_valid
+):
+    @max_length(max_length_value)
+    def stub_function():
+        return response
+
+    if is_valid:
+        assert stub_function() == response
+    else:
+        with pytest.raises(ValueError) as e:
+            stub_function()
+        assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+@pytest.mark.parametrize(
+    "response, min_length_value, is_valid",
+    [
+        ("foo", 3, True),
+        ("foo", 2, True),
+        ("foo", 4, False),
+        ("foo", 0, True),
+        ("foo", -1, True),
+        ("", 0, True),
+        ("", 1, False),
+        ("", -1, True),
+    ],
+)
+def test_Should_validate_min_length_When_decorated_with_min_length(
+    response, min_length_value, is_valid
+):
+    @min_length(min_length_value)
+    def stub_function():
+        return response
+
+    if is_valid:
+        assert stub_function() == response
+    else:
+        with pytest.raises(ValueError) as e:
+            stub_function()
+        assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+
+def test_Should_check_value_is_in_enum_When_decorated_with_is_in_enum():
+    class StubEnum(Enum):
+        A = "A"
+        B = "B"
+
+    @is_in_enum(StubEnum)
+    def stub_function(value):
+        return value
+
+    assert stub_function(StubEnum.A) == StubEnum.A
+    with pytest.raises(ValueError) as e:
+        assert stub_function("C")
+    assert str(e.value) == 'Validation failed for "stub_function" method.'
+
+    @is_in_enum(StubEnum, use_value=True)
+    def stub_function_2(value):
+        return value
+
+    assert stub_function_2("A") == "A"
+    with pytest.raises(ValueError) as e:
+        assert stub_function_2("C")
+    assert str(e.value) == 'Validation failed for "stub_function_2" method.'
+
+
+@pytest.mark.parametrize(
+    "import_name",
+    [
+        "is_datatype",
+        "is_not_empty",
+        "is_in_range",
+        "matches_pattern",
+        "max_length",
+        "min_length",
+        "is_in_enum",
+        "__version__",
+        "__license__",
+        "__author__",
+        "__description__",
+    ],
+)
+def test_Should_expose_all_methods_and_constants_When_deconfig_validations_is_imported(
+    import_name,
+):
+    import deconfig.validations as module  # pylint: disable=import-outside-toplevel
+
+    assert hasattr(module, import_name)


### PR DESCRIPTION
# Refactored validations and transformers

## Transformers

Moved transformers to `deconfig.transformers` module.
Following transformers were added out of box:
- string
- integer
- floating
- boolean
- comma_separated_array_string
- cast_datatype

Other than these also exposed `transform` decorator that takes a callback to transform response.

## Validations

Moved validations to `deconfig.validations` module.
Following validations were added:
- is_datatype
- is_not_empty
- is_in_range
- matches_pattern
- max_length
- min_length
- is_in_enum

Also, similar to transformers, exposed `validate` which takes a callable argument. This callback will be passed the response of the decorated method, using which it can do validations.

Validation callbacks are supposed to not return anything, and raise ValueError to get default validation error, or any error to indicate user of custom validation issues.
