### PR TITLE
Changed logic of cache reset

### DIFF
--- a/src/deconfig/__init__.py
+++ b/src/deconfig/__init__.py
@@ -67,9 +67,9 @@ def _decorated_config_decorator(getter_function: Callable[..., T]) -> Callable[.
     return decorated_config_wrapper
 
 
-def _reset_deconfig_cache(obj: T) -> T:
+def reset_cache(obj: Type[AdapterBase]):
     """
-    Decorator values are cached. This method will reset cache for all fields.
+    Reset cache for all fields in the class.
     """
     for name in dir(obj):
         getter_function = getattr(obj, name)
@@ -80,7 +80,6 @@ def _reset_deconfig_cache(obj: T) -> T:
         getter_function = FieldUtil.get_original_function(getter_function)
         if FieldUtil.has_cached_response(getter_function):
             FieldUtil.delete_cached_response(getter_function)
-    return obj
 
 
 def field(name: str) -> Callable[..., T]:
@@ -179,9 +178,6 @@ def config(adapters: Optional[List[AdapterBase]] = None):
             # Decorate with yield, that will handle all logic
             setattr(class_, name, _decorated_config_decorator(getter_function))
 
-        # Add method to reset cache for all fields
-        if not hasattr(class_, "reset_deconfig_cache"):
-            setattr(class_, "reset_deconfig_cache", _reset_deconfig_cache)
         return class_
 
     return wrapper
@@ -192,6 +188,7 @@ __all__ = [
     "optional",
     "add_adapter",
     "set_default_adapters",
+    "reset_cache",
     "config",
     # Adapters
     "EnvAdapter",

--- a/tests/test_deconfig/test_deconfig.py
+++ b/tests/test_deconfig/test_deconfig.py
@@ -579,6 +579,7 @@ class TestResetCache:
     def test_Should_reset_cache_When_reset_cache_is_invoked(self):
         class AdapterStub(AdapterBase):
             """Stub Adapter"""
+
             is_first_invoke = True
 
             def get_field(self, field_name, method, *_, **__):
@@ -590,6 +591,7 @@ class TestResetCache:
         @config([AdapterStub()])
         class StubConfig:
             """Stub Config"""
+
             @field(name="test")
             def stub_field(self):
                 """
@@ -604,7 +606,8 @@ class TestResetCache:
 
     def test_Should_do_nothing_When_reset_cache_is_invoked_on_non_set_cache(self):
         class AdapterStub(AdapterBase):
-            """ Stub adapter """
+            """Stub adapter"""
+
             is_first_invoke = True
 
             def get_field(self, field_name, method, *_, **__):
@@ -612,7 +615,8 @@ class TestResetCache:
 
         @config([AdapterStub()])
         class StubConfig:
-            """ Stub Config """
+            """Stub Config"""
+
             @field(name="test")
             def stub_field(self):
                 """

--- a/tests/test_deconfig/test_deconfig.py
+++ b/tests/test_deconfig/test_deconfig.py
@@ -578,6 +578,7 @@ class TestDecoratedConfigDecorator:
 class TestResetCache:
     def test_Should_reset_cache_When_reset_cache_is_invoked(self):
         class AdapterStub(AdapterBase):
+            """Stub Adapter"""
             is_first_invoke = True
 
             def get_field(self, field_name, method, *_, **__):
@@ -588,6 +589,7 @@ class TestResetCache:
 
         @config([AdapterStub()])
         class StubConfig:
+            """Stub Config"""
             @field(name="test")
             def stub_field(self):
                 """
@@ -602,6 +604,7 @@ class TestResetCache:
 
     def test_Should_do_nothing_When_reset_cache_is_invoked_on_non_set_cache(self):
         class AdapterStub(AdapterBase):
+            """ Stub adapter """
             is_first_invoke = True
 
             def get_field(self, field_name, method, *_, **__):
@@ -609,6 +612,7 @@ class TestResetCache:
 
         @config([AdapterStub()])
         class StubConfig:
+            """ Stub Config """
             @field(name="test")
             def stub_field(self):
                 """

--- a/tests/test_deconfig/test_deconfig.py
+++ b/tests/test_deconfig/test_deconfig.py
@@ -205,7 +205,7 @@ class TestAddAdapter:
 
         stub_config = StubConfig()
         assert stub_config.stub_field() == "stub_adapter_response_2"
-        stub_config.reset_deconfig_cache()
+        deconfig.reset_cache(stub_config)
         assert stub_config.stub_field() == "stub_adapter_response_1"
         with pytest.raises(AdapterError):
             stub_adapter_2.get_field("test", stub_config.stub_field)
@@ -452,18 +452,6 @@ class TestConfig:
         stub_config = StubConfig()
         assert FieldUtil.has_original_function(stub_config.field_stub)
 
-    def test_Should_add_reset_deconfig_cache_method_When_class_is_decorated_with_config(
-        self,
-    ):
-        @config()
-        class StubConfig:
-            @field(name="test")
-            def field_stub(self):
-                """Stub Field"""
-
-        stub_config = StubConfig()
-        assert hasattr(stub_config, "reset_deconfig_cache")
-
     def test_Should_not_create_reset_deconfig_cache_When_class_already_has_reset_deconfig_cache_method(
         self,
     ):
@@ -546,7 +534,7 @@ class TestDecoratedConfigDecorator:
         assert response() == 1
         assert adapter.get_field.call_count == 1
 
-    def test_Should_rebuild_value_When_cache_reset_using_reset_deconfig_cache(self):
+    def test_Should_rebuild_value_When_cache_reset_using_reset_cache(self):
         adapter = MagicMock(AdapterBase)
         adapter.get_field.side_effect = [AdapterError, 1, 2]
 
@@ -561,11 +549,11 @@ class TestDecoratedConfigDecorator:
         assert stub_config.stub_field() == 0
         assert stub_config.stub_field() == 0
         assert adapter.get_field.call_count == 1
-        stub_config.reset_deconfig_cache()
+        deconfig.reset_cache(stub_config)
         assert stub_config.stub_field() == 1
         assert stub_config.stub_field() == 1
         assert adapter.get_field.call_count == 2
-        stub_config.reset_deconfig_cache()
+        deconfig.reset_cache(stub_config)
         assert stub_config.stub_field() == 2
         assert stub_config.stub_field() == 2
         assert adapter.get_field.call_count == 3
@@ -585,3 +573,48 @@ class TestDecoratedConfigDecorator:
         assert adapter_1.get_field.call_count == 1
         assert adapter_2.get_field.call_count == 1
         assert adapter_3.get_field.call_count == 0
+
+
+class TestResetCache:
+    def test_Should_reset_cache_When_reset_cache_is_invoked(self):
+        class AdapterStub(AdapterBase):
+            is_first_invoke = True
+
+            def get_field(self, field_name, method, *_, **__):
+                if self.is_first_invoke:
+                    self.is_first_invoke = False
+                    return 1
+                return 2
+
+        @config([AdapterStub()])
+        class StubConfig:
+            @field(name="test")
+            def stub_field(self):
+                """
+                Stub field
+                """
+
+        stub_config = StubConfig()
+        assert stub_config.stub_field() == 1
+        assert stub_config.stub_field() == 1
+        deconfig.reset_cache(stub_config)
+        assert stub_config.stub_field() == 2
+
+    def test_Should_do_nothing_When_reset_cache_is_invoked_on_non_set_cache(self):
+        class AdapterStub(AdapterBase):
+            is_first_invoke = True
+
+            def get_field(self, field_name, method, *_, **__):
+                return 1
+
+        @config([AdapterStub()])
+        class StubConfig:
+            @field(name="test")
+            def stub_field(self):
+                """
+                Stub field
+                """
+
+        stub_config = StubConfig()
+        deconfig.reset_cache(stub_config)
+        assert stub_config.stub_field() == 1


### PR DESCRIPTION
# Reset Cache

Used to add a reset_deconfig_cache method to class itself, but that was not very intuitive to use. So, changed it to one public method that can be imported from deconfig like `from deconfig import reset_cache`
This can then be used to reset cache of any existing config, for ex: `reset_cache(config)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
  - Modified cache reset mechanism for better clarity and efficiency.
  - Updated function parameters and descriptions for improved readability.
  
- **Tests**
  - Refactored test cases to align with the new cache reset mechanism.
  - Added new test class `TestResetCache` to ensure robust cache reset functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->